### PR TITLE
(Fix) tokens reservation update

### DIFF
--- a/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/001_SafeMathLibExt.sol
+++ b/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/001_SafeMathLibExt.sol
@@ -1,4 +1,4 @@
-// Created using ICO Wizard https://github.com/oraclesorg/ico-wizard by Oracles Network 
+// Created using ICO Wizard https://github.com/poanetwork/ico-wizard by POA Network
 /**
  * This smart contract code is Copyright 2017 TokenMarket Ltd. For more information see https://tokenmarket.net
  *

--- a/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/003_CrowdsaleTokenExt.sol
+++ b/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/003_CrowdsaleTokenExt.sol
@@ -1,3 +1,4 @@
+// Created using ICO Wizard https://github.com/poanetwork/ico-wizard by POA Network
 pragma solidity ^0.4.11;
 
 

--- a/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/005_FlatPricingExt.sol
+++ b/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/005_FlatPricingExt.sol
@@ -1,3 +1,4 @@
+// Created using ICO Wizard https://github.com/poanetwork/ico-wizard by POA Network
 pragma solidity ^0.4.11;
 
 

--- a/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/007_MintedTokenCappedCrowdsaleExt.sol
+++ b/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/007_MintedTokenCappedCrowdsaleExt.sol
@@ -1,3 +1,4 @@
+// Created using ICO Wizard https://github.com/poanetwork/ico-wizard by POA Network
 // Temporarily have SafeMath here until all contracts have been migrated to SafeMathLib version from OpenZeppelin
 
 pragma solidity ^0.4.8;

--- a/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/009_ReservedTokensFinalizeAgent.sol
+++ b/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/009_ReservedTokensFinalizeAgent.sol
@@ -1,3 +1,4 @@
+// Created using ICO Wizard https://github.com/poanetwork/ico-wizard by POA Network
 pragma solidity ^0.4.11;
 
 


### PR DESCRIPTION
There are some problems with `ReservedTokensFinalizeAgent` and `MintableTokenExt`

**Problems**: 
1. Reserved tokens can be changed anytime during crowdsale
2. The array of reserved tokens is limited by 256 elements due to using `uint8` in loop.
3. If there are multiple addresses with reserved tokens in percents, percentage calculates incorrectly (`tokensSold` is increasing for every new reserved address).
4. Distributing of huge amount of reserved tokens can cause out gas problem for finalization of crowdsale.

**Solutions**: 
1. Reserved tokens can be set only once
2. Change the type in the loop to `uint256`.
3. prevent increasing of `tokensSold` in reserved tokens distribution to solve incorrect reservation in percents.
4. `distributeReservedTokens(uint reservedTokensDistributionBatch)` method is introduced to prevent out of gas problem on finalization. Method should be called by owner before finalization, if some tokens are reserved. Finalization cannot be called before all tokens are distributed. Method of distribution can be called many times with batches until all tokens won't be distributed.

Other improvements:
- remove 2 loops in reserved tokens distribution
- `isReserved` is added to `ReservedTokensData` structure to track, is address is reserved or not
- `isDistributed` is added to `ReservedTokensData` structure to track, did address get all reserved tokens or not
- rename `getReservedTokensListValInTokens` to `getReservedTokens`
- rename `getReservedTokensListValInPercentageUnit` to `getReservedPercentageUnit`
- rename `getReservedTokensListValInPercentageDecimals` to `getReservedPercentageDecimals`
- `isAddressReserved` method is added to `MintableTokenExt` contract to track, if address is reserved
- `areTokensDistributedForAddress` method is added to `MintableTokenExt` contract to track, if address got reserved tokens
- `finalizeReservedAddress` method is added to `MintableTokenExt` contract to mark, that address got all reserved tokens
- `reservedTokensDestinationsAreSet` method is added to `MintableTokenExt` contract to track, if reserved addresses are set or not

These fixes are already in live ICO wizard:
- update all methods for whitelisting due to typo
- `claimTokens` method is added
- tier name property is added
- additional checks in methods for whitelisting (light, huge refactor will be in the next update)