### PR TITLE
(Fix) changes to crowdsale contract

### DIFF
--- a/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/007_MintedTokenCappedCrowdsaleExt.sol
+++ b/icowizard_Mainnet_0xa5F8fC0921880Cb7342368BD128eb8050442B1a1/007_MintedTokenCappedCrowdsaleExt.sol
@@ -1,4 +1,4 @@
-// Created using ICO Wizard https://github.com/oraclesorg/ico-wizard by Oracles Network 
+// Created using ICO Wizard https://github.com/poanetwork/ico-wizard by POA Network 
 // Temporarily have SafeMath here until all contracts have been migrated to SafeMathLib version from OpenZeppelin
 
 pragma solidity ^0.4.8;
@@ -231,6 +231,8 @@ contract Haltable is Ownable {
  */
 contract PricingStrategy {
 
+  address public tier;
+
   /** Interface declaration. */
   function isPricingStrategy() public constant returns (bool) {
     return true;
@@ -252,6 +254,9 @@ contract PricingStrategy {
   function isPresalePurchase(address purchaser) public constant returns (bool) {
     return false;
   }
+
+  /* How many weis one token costs */
+  function updateRate(uint newOneTokenInWei) public;
 
   /**
    * When somebody tries to buy tokens for X eth, calculate how many tokens they get.
@@ -295,11 +300,12 @@ contract FinalizeAgent {
    */
   function isSane() public constant returns (bool);
 
+  function distributeReservedTokens(uint reservedTokensDistributionBatch);
+
   /** Called once by crowdsale finalize() if the sale was success. */
   function finalizeCrowdsale();
 
 }
-
 /**
  * This smart contract code is Copyright 2017 TokenMarket Ltd. For more information see https://tokenmarket.net
  *
@@ -366,6 +372,9 @@ contract CrowdsaleExt is Haltable {
   /* Post-success callback */
   FinalizeAgent public finalizeAgent;
 
+  /* name of the crowdsale tier */
+  string public name;
+
   /* tokens will be transfered from this address */
   address public multisigWallet;
 
@@ -390,33 +399,19 @@ contract CrowdsaleExt is Haltable {
   /* How many distinct addresses have invested */
   uint public investorCount = 0;
 
-  /* How much wei we have returned back to the contract after a failed crowdfund. */
-  uint public loadedRefund = 0;
-
-  /* How much wei we have given back to investors.*/
-  uint public weiRefunded = 0;
-
   /* Has this crowdsale been finalized */
   bool public finalized;
-
-  /* Do we need to have unique contributor id for each customer */
-  bool public requireCustomerId;
 
   bool public isWhiteListed;
 
   address[] public joinedCrowdsales;
-  uint public joinedCrowdsalesLen = 0;
-
-  address public lastCrowdsale;
-
-  /**
-    * Do we verify that contributor has been cleared on the server side (accredited investors only).
-    * This method was first used in FirstBlood crowdsale to ensure all contributors have accepted terms on sale (on the web).
-    */
-  bool public requiredSignedAddress;
-
-  /* Server side address that signed allowed contributors (Ethereum addresses) that can participate the crowdsale */
-  address public signerAddress;
+  uint8 public joinedCrowdsalesLen = 0;
+  uint8 public joinedCrowdsalesLenMax = 50;
+  struct JoinedCrowdsaleStatus {
+    bool isJoined;
+    uint8 position;
+  }
+  mapping (address => JoinedCrowdsaleStatus) joinedCrowdsaleState;
 
   /** How much ETH each address has invested to this crowdsale */
   mapping (address => uint256) public investedAmountOf;
@@ -436,6 +431,9 @@ contract CrowdsaleExt is Haltable {
   /** Addresses that are allowed to invest even before ICO offical opens. For testing, for ICO partners, etc. */
   mapping (address => WhiteListData) public earlyParticipantWhitelist;
 
+  /** List of whitelisted addresses */
+  address[] public whitelistedParticipants;
+
   /** This is for manul testing for the interaction from owner wallet. You can set it to any value and inspect this in blockchain explorer to see that crowdsale interaction works. */
   uint public ownerTestValue;
 
@@ -447,21 +445,15 @@ contract CrowdsaleExt is Haltable {
    * - Success: Minimum funding goal reached
    * - Failure: Minimum funding goal not reached before ending time
    * - Finalized: The finalized has been called and succesfully executed
-   * - Refunding: Refunds are loaded on the contract for reclaim.
    */
-  enum State{Unknown, Preparing, PreFunding, Funding, Success, Failure, Finalized, Refunding}
+  enum State{Unknown, Preparing, PreFunding, Funding, Success, Failure, Finalized}
 
   // A new investment was made
   event Invested(address investor, uint weiAmount, uint tokenAmount, uint128 customerId);
 
-  // Refund was processed for a contributor
-  event Refund(address investor, uint weiAmount);
-
-  // The rules were changed what kind of investments we accept
-  event InvestmentPolicyChanged(bool newRequireCustomerId, bool newRequiredSignedAddress, address newSignerAddress);
-
   // Address early participation whitelist status changed
-  event Whitelisted(address addr, bool status);
+  event Whitelisted(address addr, bool status, uint minCap, uint maxCap);
+  event WhitelistItemChanged(address addr, bool status, uint minCap, uint maxCap);
 
   // Crowdsale start time has been changed
   event StartsAtChanged(uint newStartsAt);
@@ -469,9 +461,11 @@ contract CrowdsaleExt is Haltable {
   // Crowdsale end time has been changed
   event EndsAtChanged(uint newEndsAt);
 
-  function CrowdsaleExt(address _token, PricingStrategy _pricingStrategy, address _multisigWallet, uint _start, uint _end, uint _minimumFundingGoal, bool _isUpdatable, bool _isWhiteListed) {
+  function CrowdsaleExt(string _name, address _token, PricingStrategy _pricingStrategy, address _multisigWallet, uint _start, uint _end, uint _minimumFundingGoal, bool _isUpdatable, bool _isWhiteListed) {
 
     owner = msg.sender;
+
+    name = _name;
 
     token = FractionalERC20Ext(_token);
 
@@ -601,18 +595,7 @@ contract CrowdsaleExt is Haltable {
     if(!multisigWallet.send(weiAmount)) throw;
 
     if (isWhiteListed) {
-      uint num = 0;
-      for (var i = 0; i < joinedCrowdsalesLen; i++) {
-        if (this == joinedCrowdsales[i]) 
-          num = i;
-      }
-
-      if (num + 1 < joinedCrowdsalesLen) {
-        for (var j = num + 1; j < joinedCrowdsalesLen; j++) {
-          CrowdsaleExt crowdsale = CrowdsaleExt(joinedCrowdsales[j]);
-          crowdsale.updateEarlyParicipantWhitelist(msg.sender, this, tokenAmount);
-        }
-      }
+      updateInheritedEarlyParticipantWhitelist(tokenAmount);
     }
 
     // Tell us invest was success
@@ -620,79 +603,10 @@ contract CrowdsaleExt is Haltable {
   }
 
   /**
-   * Preallocate tokens for the early investors.
-   *
-   * Preallocated tokens have been sold before the actual crowdsale opens.
-   * This function mints the tokens and moves the crowdsale needle.
-   *
-   * Investor count is not handled; it is assumed this goes for multiple investors
-   * and the token distribution happens outside the smart contract flow.
-   *
-   * No money is exchanged, as the crowdsale team already have received the payment.
-   *
-   * @param fullTokens tokens as full tokens - decimal places added internally
-   * @param weiPrice Price of a single full token in wei
-   *
-   */
-  function preallocate(address receiver, uint fullTokens, uint weiPrice) public onlyOwner {
-
-    uint tokenAmount = fullTokens * 10**token.decimals();
-    uint weiAmount = weiPrice * fullTokens; // This can be also 0, we give out tokens for free
-
-    weiRaised = weiRaised.plus(weiAmount);
-    tokensSold = tokensSold.plus(tokenAmount);
-
-    investedAmountOf[receiver] = investedAmountOf[receiver].plus(weiAmount);
-    tokenAmountOf[receiver] = tokenAmountOf[receiver].plus(tokenAmount);
-
-    assignTokens(receiver, tokenAmount);
-
-    // Tell us invest was success
-    Invested(receiver, weiAmount, tokenAmount, 0);
-  }
-
-  /**
-   * Allow anonymous contributions to this crowdsale.
-   */
-  function investWithSignedAddress(address addr, uint128 customerId, uint8 v, bytes32 r, bytes32 s) public payable {
-     bytes32 hash = sha256(addr);
-     if (ecrecover(hash, v, r, s) != signerAddress) throw;
-     if(customerId == 0) throw;  // UUIDv4 sanity check
-     investInternal(addr, customerId);
-  }
-
-  /**
-   * Track who is the customer making the payment so we can send thank you email.
-   */
-  function investWithCustomerId(address addr, uint128 customerId) public payable {
-    if(requiredSignedAddress) throw; // Crowdsale allows only server-side signed participants
-    if(customerId == 0) throw;  // UUIDv4 sanity check
-    investInternal(addr, customerId);
-  }
-
-  /**
    * Allow anonymous contributions to this crowdsale.
    */
   function invest(address addr) public payable {
-    if(requireCustomerId) throw; // Crowdsale needs to track participants for thank you email
-    if(requiredSignedAddress) throw; // Crowdsale allows only server-side signed participants
     investInternal(addr, 0);
-  }
-
-  /**
-   * Invest to tokens, recognize the payer and clear his address.
-   *
-   */
-  function buyWithSignedAddress(uint128 customerId, uint8 v, bytes32 r, bytes32 s) public payable {
-    investWithSignedAddress(msg.sender, customerId, v, r, s);
-  }
-
-  /**
-   * Invest to tokens, recognize the payer.
-   *
-   */
-  function buyWithCustomerId(uint128 customerId) public payable {
-    investWithCustomerId(msg.sender, customerId);
   }
 
   /**
@@ -702,6 +616,18 @@ contract CrowdsaleExt is Haltable {
    */
   function buy() public payable {
     invest(msg.sender);
+  }
+
+  function distributeReservedTokens(uint reservedTokensDistributionBatch) public inState(State.Success) onlyOwner stopInEmergency {
+    // Already finalized
+    if(finalized) {
+      throw;
+    }
+
+    // Finalizing is optional. We only call it if we are given a finalizing agent.
+    if(address(finalizeAgent) != address(0)) {
+      finalizeAgent.distributeReservedTokens(reservedTokensDistributionBatch);
+    }
   }
 
   /**
@@ -717,7 +643,7 @@ contract CrowdsaleExt is Haltable {
     }
 
     // Finalizing is optional. We only call it if we are given a finalizing agent.
-    if(address(finalizeAgent) != 0) {
+    if(address(finalizeAgent) != address(0)) {
       finalizeAgent.finalizeCrowdsale();
     }
 
@@ -729,7 +655,9 @@ contract CrowdsaleExt is Haltable {
    *
    * Design choice: no state restrictions on setting this, so that we can fix fat finger mistakes.
    */
-  function setFinalizeAgent(FinalizeAgent addr) onlyOwner {
+  function setFinalizeAgent(FinalizeAgent addr) public onlyOwner {
+    assert(address(addr) != address(0));
+    assert(address(finalizeAgent) == address(0));
     finalizeAgent = addr;
 
     // Don't allow setting bad agent
@@ -739,74 +667,97 @@ contract CrowdsaleExt is Haltable {
   }
 
   /**
-   * Set policy do we need to have server-side customer ids for the investments.
-   *
-   */
-  function setRequireCustomerId(bool value) onlyOwner {
-    requireCustomerId = value;
-    InvestmentPolicyChanged(requireCustomerId, requiredSignedAddress, signerAddress);
-  }
-
-  /**
-   * Set policy if all investors must be cleared on the server side first.
-   *
-   * This is e.g. for the accredited investor clearing.
-   *
-   */
-  function setRequireSignedAddress(bool value, address _signerAddress) onlyOwner {
-    requiredSignedAddress = value;
-    signerAddress = _signerAddress;
-    InvestmentPolicyChanged(requireCustomerId, requiredSignedAddress, signerAddress);
-  }
-
-  /**
    * Allow addresses to do early participation.
-   *
-   * TODO: Fix spelling error in the name
    */
-  function setEarlyParicipantWhitelist(address addr, bool status, uint minCap, uint maxCap) onlyOwner {
+  function setEarlyParticipantWhitelist(address addr, bool status, uint minCap, uint maxCap) public onlyOwner {
     if (!isWhiteListed) throw;
+    assert(addr != address(0));
+    assert(maxCap > 0);
+    assert(minCap <= maxCap);
+    assert(now <= endsAt);
+
+    if (earlyParticipantWhitelist[addr].maxCap == 0) {
+      whitelistedParticipants.push(addr);
+      Whitelisted(addr, status, minCap, maxCap);
+    } else {
+      WhitelistItemChanged(addr, status, minCap, maxCap);
+    }
+
     earlyParticipantWhitelist[addr] = WhiteListData({status:status, minCap:minCap, maxCap:maxCap});
-    Whitelisted(addr, status);
   }
 
-  function setEarlyParicipantsWhitelist(address[] addrs, bool[] statuses, uint[] minCaps, uint[] maxCaps) onlyOwner {
+  function setEarlyParticipantWhitelistMultiple(address[] addrs, bool[] statuses, uint[] minCaps, uint[] maxCaps) public onlyOwner {
     if (!isWhiteListed) throw;
+    assert(now <= endsAt);
+    assert(addrs.length == statuses.length);
+    assert(statuses.length == minCaps.length);
+    assert(minCaps.length == maxCaps.length);
     for (uint iterator = 0; iterator < addrs.length; iterator++) {
-      setEarlyParicipantWhitelist(addrs[iterator], statuses[iterator], minCaps[iterator], maxCaps[iterator]);
+      setEarlyParticipantWhitelist(addrs[iterator], statuses[iterator], minCaps[iterator], maxCaps[iterator]);
     }
   }
 
-  function updateEarlyParicipantWhitelist(address addr, address contractAddr, uint tokensBought) {
-    if (tokensBought < earlyParticipantWhitelist[addr].minCap) throw;
+  function updateInheritedEarlyParticipantWhitelist(uint tokensBought) private {
     if (!isWhiteListed) throw;
-    if (addr != msg.sender && contractAddr != msg.sender) throw;
+    if (tokensBought < earlyParticipantWhitelist[msg.sender].minCap) throw;
+
+    uint8 tierPosition = getTierPosition(this);
+
+    for (uint8 j = tierPosition; j < joinedCrowdsalesLen; j++) {
+      CrowdsaleExt crowdsale = CrowdsaleExt(joinedCrowdsales[j]);
+      crowdsale.updateEarlyParticipantWhitelist(msg.sender, tokensBought);
+    }
+  }
+
+  function updateEarlyParticipantWhitelist(address addr, uint tokensBought) public {
+    if (!isWhiteListed) throw;
+    assert(addr != address(0));
+    assert(now <= endsAt);
+    assert(isTierJoined(msg.sender));
+    if (tokensBought < earlyParticipantWhitelist[addr].minCap) throw;
+    //if (addr != msg.sender && contractAddr != msg.sender) throw;
     uint newMaxCap = earlyParticipantWhitelist[addr].maxCap;
     newMaxCap = newMaxCap.minus(tokensBought);
     earlyParticipantWhitelist[addr] = WhiteListData({status:earlyParticipantWhitelist[addr].status, minCap:0, maxCap:newMaxCap});
   }
 
-  function updateJoinedCrowdsales(address addr) onlyOwner {
-    joinedCrowdsales[joinedCrowdsalesLen++] = addr;
+  function whitelistedParticipantsLength() public constant returns (uint) {
+    return whitelistedParticipants.length;
   }
 
-  function setLastCrowdsale(address addr) onlyOwner {
-    lastCrowdsale = addr;
+  function isTierJoined(address addr) public constant returns(bool) {
+    return joinedCrowdsaleState[addr].isJoined;
   }
 
-  function clearJoinedCrowdsales() onlyOwner {
-    joinedCrowdsalesLen = 0;
+  function getTierPosition(address addr) public constant returns(uint8) {
+    return joinedCrowdsaleState[addr].position;
   }
 
-  function updateJoinedCrowdsalesMultiple(address[] addrs) onlyOwner {
-    clearJoinedCrowdsales();
-    for (uint iter = 0; iter < addrs.length; iter++) {
-      if(joinedCrowdsalesLen == joinedCrowdsales.length) {
-          joinedCrowdsales.length += 1;
-      }
-      joinedCrowdsales[joinedCrowdsalesLen++] = addrs[iter];
-      if (iter == addrs.length - 1)
-        setLastCrowdsale(addrs[iter]);
+  function getLastTier() public constant returns(address) {
+    if (joinedCrowdsalesLen > 0)
+      return joinedCrowdsales[joinedCrowdsalesLen - 1];
+    else
+      return address(0);
+  }
+
+  function setJoinedCrowdsales(address addr) private onlyOwner {
+    assert(addr != address(0));
+    assert(joinedCrowdsalesLen <= joinedCrowdsalesLenMax);
+    assert(!isTierJoined(addr));
+    joinedCrowdsales.push(addr);
+    joinedCrowdsaleState[addr] = JoinedCrowdsaleStatus({
+      isJoined: true,
+      position: joinedCrowdsalesLen
+    });
+    joinedCrowdsalesLen++;
+  }
+
+  function updateJoinedCrowdsalesMultiple(address[] addrs) public onlyOwner {
+    assert(addrs.length > 0);
+    assert(joinedCrowdsalesLen == 0);
+    assert(addrs.length <= joinedCrowdsalesLenMax);
+    for (uint8 iter = 0; iter < addrs.length; iter++) {
+      setJoinedCrowdsales(addrs[iter]);
     }
   }
 
@@ -823,8 +774,15 @@ contract CrowdsaleExt is Haltable {
       throw;
     }
 
-    CrowdsaleExt lastCrowdsaleCntrct = CrowdsaleExt(lastCrowdsale);
-    if (lastCrowdsaleCntrct.finalized()) throw;
+    CrowdsaleExt lastTierCntrct = CrowdsaleExt(getLastTier());
+    if (lastTierCntrct.finalized()) throw;
+
+    uint8 tierPosition = getTierPosition(this);
+
+    for (uint8 j = 0; j < tierPosition; j++) {
+      CrowdsaleExt crowdsale = CrowdsaleExt(joinedCrowdsales[j]);
+      if (time < crowdsale.endsAt()) throw;
+    }
 
     startsAt = time;
     StartsAtChanged(startsAt);
@@ -840,7 +798,7 @@ contract CrowdsaleExt is Haltable {
    * but we trust owners know what they are doing.
    *
    */
-  function setEndsAt(uint time) onlyOwner {
+  function setEndsAt(uint time) public onlyOwner {
     if (finalized) throw;
 
     if (!isUpdatable) throw;
@@ -853,20 +811,15 @@ contract CrowdsaleExt is Haltable {
       throw;
     }
 
-    CrowdsaleExt lastCrowdsaleCntrct = CrowdsaleExt(lastCrowdsale);
-    if (lastCrowdsaleCntrct.finalized()) throw;
+    CrowdsaleExt lastTierCntrct = CrowdsaleExt(getLastTier());
+    if (lastTierCntrct.finalized()) throw;
 
-    uint num = 0;
-    for (var i = 0; i < joinedCrowdsalesLen; i++) {
-      if (this == joinedCrowdsales[i]) 
-        num = i;
-    }
 
-    if (num + 1 < joinedCrowdsalesLen) {
-      for (var j = num + 1; j < joinedCrowdsalesLen; j++) {
-        CrowdsaleExt crowdsale = CrowdsaleExt(joinedCrowdsales[j]);
-        if (time > crowdsale.startsAt()) throw;
-      }
+    uint8 tierPosition = getTierPosition(this);
+
+    for (uint8 j = tierPosition + 1; j < joinedCrowdsalesLen; j++) {
+      CrowdsaleExt crowdsale = CrowdsaleExt(joinedCrowdsales[j]);
+      if (time > crowdsale.startsAt()) throw;
     }
 
     endsAt = time;
@@ -878,7 +831,9 @@ contract CrowdsaleExt is Haltable {
    *
    * Design choice: no state restrictions on the set, so that we can fix fat finger mistakes.
    */
-  function setPricingStrategy(PricingStrategy _pricingStrategy) onlyOwner {
+  function setPricingStrategy(PricingStrategy _pricingStrategy) public onlyOwner {
+    assert(address(_pricingStrategy) != address(0));
+    assert(address(pricingStrategy) == address(0));
     pricingStrategy = _pricingStrategy;
 
     // Don't allow setting bad agent
@@ -902,31 +857,6 @@ contract CrowdsaleExt is Haltable {
     }
 
     multisigWallet = addr;
-  }
-
-  /**
-   * Allow load refunds back on the contract for the refunding.
-   *
-   * The team can transfer the funds back on the smart contract in the case the minimum goal was not reached..
-   */
-  function loadRefund() public payable inState(State.Failure) {
-    if(msg.value == 0) throw;
-    loadedRefund = loadedRefund.plus(msg.value);
-  }
-
-  /**
-   * Investors can claim refund.
-   *
-   * Note that any refunds from proxy buyers should be handled separately,
-   * and not through this contract.
-   */
-  function refund() public inState(State.Refunding) {
-    uint256 weiValue = investedAmountOf[msg.sender];
-    if (weiValue == 0) throw;
-    investedAmountOf[msg.sender] = 0;
-    weiRefunded = weiRefunded.plus(weiValue);
-    Refund(msg.sender, weiValue);
-    if (!msg.sender.send(weiValue)) throw;
   }
 
   /**
@@ -963,7 +893,6 @@ contract CrowdsaleExt is Haltable {
     else if (block.timestamp < startsAt) return State.PreFunding;
     else if (block.timestamp <= endsAt && !isCrowdsaleFull()) return State.Funding;
     else if (isMinimumGoalReached()) return State.Success;
-    else if (!isMinimumGoalReached() && weiRaised > 0 && loadedRefund >= weiRaised) return State.Refunding;
     else return State.Failure;
   }
 
@@ -1007,9 +936,9 @@ contract CrowdsaleExt is Haltable {
    *
    * @return true if taking this investment would break our cap rules
    */
-  function isBreakingCap(uint weiAmount, uint tokenAmount, uint weiRaisedTotal, uint tokensSoldTotal) constant returns (bool limitBroken);
+  function isBreakingCap(uint weiAmount, uint tokenAmount, uint weiRaisedTotal, uint tokensSoldTotal) public constant returns (bool limitBroken);
 
-  function isBreakingInvestorCap(address receiver, uint tokenAmount) constant returns (bool limitBroken);
+  function isBreakingInvestorCap(address receiver, uint tokenAmount) public constant returns (bool limitBroken);
 
   /**
    * Check if the current crowdsale is full and we can no longer sell any tokens.
@@ -1136,34 +1065,67 @@ contract MintableTokenExt is StandardToken, Ownable {
     uint inTokens;
     uint inPercentageUnit;
     uint inPercentageDecimals;
+    bool isReserved;
+    bool isDistributed;
   }
 
   mapping (address => ReservedTokensData) public reservedTokensList;
   address[] public reservedTokensDestinations;
   uint public reservedTokensDestinationsLen = 0;
+  bool reservedTokensDestinationsAreSet = false;
 
-  function setReservedTokensList(address addr, uint inTokens, uint inPercentageUnit, uint inPercentageDecimals) onlyOwner {
-    reservedTokensDestinations.push(addr);
-    reservedTokensDestinationsLen++;
-    reservedTokensList[addr] = ReservedTokensData({inTokens:inTokens, inPercentageUnit:inPercentageUnit, inPercentageDecimals: inPercentageDecimals});
+  function setReservedTokensList(address addr, uint inTokens, uint inPercentageUnit, uint inPercentageDecimals) private canMint onlyOwner {
+    assert(addr != address(0));
+    if (!isAddressReserved(addr)) {
+      reservedTokensDestinations.push(addr);
+      reservedTokensDestinationsLen++;
+    }
+
+    reservedTokensList[addr] = ReservedTokensData({
+      inTokens: inTokens, 
+      inPercentageUnit: inPercentageUnit, 
+      inPercentageDecimals: inPercentageDecimals,
+      isReserved: true,
+      isDistributed: false
+    });
   }
 
-  function getReservedTokensListValInTokens(address addr) constant returns (uint inTokens) {
+  function finalizeReservedAddress(address addr) onlyMintAgent canMint {
+    ReservedTokensData storage reservedTokensData = reservedTokensList[addr];
+    reservedTokensData.isDistributed = true;
+  }
+
+  function isAddressReserved(address addr) constant returns (bool isReserved) {
+    return reservedTokensList[addr].isReserved;
+  }
+
+  function areTokensDistributedForAddress(address addr) constant returns (bool isDistributed) {
+    return reservedTokensList[addr].isDistributed;
+  }
+
+  function getReservedTokens(address addr) constant returns (uint inTokens) {
     return reservedTokensList[addr].inTokens;
   }
 
-  function getReservedTokensListValInPercentageUnit(address addr) constant returns (uint inPercentageUnit) {
+  function getReservedPercentageUnit(address addr) constant returns (uint inPercentageUnit) {
     return reservedTokensList[addr].inPercentageUnit;
   }
 
-  function getReservedTokensListValInPercentageDecimals(address addr) constant returns (uint inPercentageDecimals) {
+  function getReservedPercentageDecimals(address addr) constant returns (uint inPercentageDecimals) {
     return reservedTokensList[addr].inPercentageDecimals;
   }
 
-  function setReservedTokensListMultiple(address[] addrs, uint[] inTokens, uint[] inPercentageUnit, uint[] inPercentageDecimals) onlyOwner {
+  function setReservedTokensListMultiple(address[] addrs, uint[] inTokens, uint[] inPercentageUnit, uint[] inPercentageDecimals) canMint onlyOwner {
+    assert(!reservedTokensDestinationsAreSet);
+    assert(addrs.length == inTokens.length);
+    assert(inTokens.length == inPercentageUnit.length);
+    assert(inPercentageUnit.length == inPercentageDecimals.length);
     for (uint iterator = 0; iterator < addrs.length; iterator++) {
-      setReservedTokensList(addrs[iterator], inTokens[iterator], inPercentageUnit[iterator], inPercentageDecimals[iterator]);
+      if (addrs[iterator] != address(0)) {
+        setReservedTokensList(addrs[iterator], inTokens[iterator], inPercentageUnit[iterator], inPercentageDecimals[iterator]);
+      }
     }
+    reservedTokensDestinationsAreSet = true;
   }
 
   /**
@@ -1203,7 +1165,6 @@ contract MintableTokenExt is StandardToken, Ownable {
   }
 }
 
-
 /**
  * ICO crowdsale contract that is capped by amout of tokens.
  *
@@ -1216,7 +1177,7 @@ contract MintedTokenCappedCrowdsaleExt is CrowdsaleExt {
   /* Maximum amount of tokens this crowdsale can sell. */
   uint public maximumSellableTokens;
 
-  function MintedTokenCappedCrowdsaleExt(address _token, PricingStrategy _pricingStrategy, address _multisigWallet, uint _start, uint _end, uint _minimumFundingGoal, uint _maximumSellableTokens, bool _isUpdatable, bool _isWhiteListed) CrowdsaleExt(_token, _pricingStrategy, _multisigWallet, _start, _end, _minimumFundingGoal, _isUpdatable, _isWhiteListed) {
+  function MintedTokenCappedCrowdsaleExt(string _name, address _token, PricingStrategy _pricingStrategy, address _multisigWallet, uint _start, uint _end, uint _minimumFundingGoal, uint _maximumSellableTokens, bool _isUpdatable, bool _isWhiteListed) CrowdsaleExt(_name, _token, _pricingStrategy, _multisigWallet, _start, _end, _minimumFundingGoal, _isUpdatable, _isWhiteListed) {
     maximumSellableTokens = _maximumSellableTokens;
   }
 
@@ -1250,13 +1211,24 @@ contract MintedTokenCappedCrowdsaleExt is CrowdsaleExt {
 
   function setMaximumSellableTokens(uint tokens) onlyOwner {
     if (finalized) throw;
-
     if (!isUpdatable) throw;
+    if (now >= startsAt) throw;
 
-    CrowdsaleExt lastCrowdsaleCntrct = CrowdsaleExt(lastCrowdsale);
-    if (lastCrowdsaleCntrct.finalized()) throw;
+    CrowdsaleExt lastTierCntrct = CrowdsaleExt(getLastTier());
+    if (lastTierCntrct.finalized()) throw;
 
     maximumSellableTokens = tokens;
     MaximumSellableTokensChanged(maximumSellableTokens);
+  }
+
+  function updateRate(uint newOneTokenInWei) onlyOwner {
+    if (finalized) throw;
+    if (!isUpdatable) throw;
+    if (now >= startsAt) throw;
+
+    CrowdsaleExt lastTierCntrct = CrowdsaleExt(getLastTier());
+    if (lastTierCntrct.finalized()) throw;
+
+    pricingStrategy.updateRate(newOneTokenInWei);
   }
 }


### PR DESCRIPTION
**Problems**: 
1. Refund methods are in the contracts, but refund cannot be reached from ICO Wizard
2. Preallocate method gives to owner ability to sell tokens for early investors.
3. Setting and updating of `joinedCrowdsales` without limitations.
4. `setFinalizeAgent`, `setPricingStrategy` can be set multiple times.

**Solutions**:
1. Remove `refund`, `loadRefund` functions and all variables relating to refund from `CrowdsaleExt` contract
2. Since ICO Wizard support tiers structure we don't need this method. It is deleted.
3. Partially solved here https://github.com/poanetwork/ico-wizard-audit/pull/4. `joinedCrowdsales` can be set once. Some additional checks are added. In this PS: `clearJoinedCrowdsales` is removed, since array can be set only once, we don't need it.
4. `setFinalizeAgent`, `setPricingStrategy` can be set only once.

Other improvements:
- `joinedCrowdsalesLenMax` is introduced
- `JoinedCrowdsaleStatus` struct is introduced
- `mapping (address => JoinedCrowdsaleStatus) joinedCrowdsaleState` to track whether address is joined and its position in `joinedCrowdsales` array
- `WhitelistItemChanged` event is introduced
- `setEarlyParticipantsWhitelist` is renamed to `setEarlyParticipantWhitelistMultiple`
- Additional checks are added for addition to whitelist items